### PR TITLE
F.27: Example fix

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2583,7 +2583,7 @@ Using `std::shared_ptr` is the standard way to represent shared ownership. That 
 
 ##### Example
 
-    shared_ptr<Image> im { read_image(somewhere) };
+    shared_ptr<const Image> im { read_image(somewhere) };
 
     std::thread t0 {shade, args0, top_left, im};
     std::thread t1 {shade, args1, top_right, im};


### PR DESCRIPTION
It is usually a bad idea to share mutable object between threads, this can lead to a race condition or unnecessary thread contention. 
This change request is intended to improve correctness of example in concurrent environment.
